### PR TITLE
Hyperlink new DOIs against preferred resolver

### DIFF
--- a/iseedelve/iseedelve/static/search.js
+++ b/iseedelve/iseedelve/static/search.js
@@ -558,7 +558,7 @@ $(document).ready(function(){
 											}
 											else if (typeof pub['citation']['DOI'] !== 'undefined')
 											{
-												citation_url = "href='http://dx.doi.org/"+pub['citation']['DOI']+"'";
+												citation_url = "href='https://doi.org/"+pub['citation']['DOI']+"'";
 											}
 											else
 											{


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!